### PR TITLE
Add the extension to record originating ip for roundcube, fixes #895

### DIFF
--- a/incubator/RoundcubePlugins/README.md
+++ b/incubator/RoundcubePlugins/README.md
@@ -84,6 +84,10 @@ See [GPL v2](http://www.gnu.org/licenses/gpl-2.0.html "GPL v2")
 **zipdownload**
 
 	Adds an option to download all attachments of a message in one zip file.
+
+**additional_message_headers**
+
+	Adds a header identifying the originating ip for the mails sent via webmail.
 	
 ### REQUIREMENTS
 

--- a/incubator/RoundcubePlugins/backend/RoundcubePlugins.pm
+++ b/incubator/RoundcubePlugins/backend/RoundcubePlugins.pm
@@ -39,7 +39,6 @@ use iMSCP::Execute;
 use iMSCP::File;
 use Servers::cron;
 use JSON;
-
 use parent 'Common::SingletonClass';
 
 =head1 DESCRIPTION
@@ -181,6 +180,9 @@ sub disable
 	
 	$rs = $self->_setRoundcubePlugin('zipdownload', 'remove');
 	return $rs if $rs;	
+
+	$rs = $self->_setRoundcubePlugin('additional_message_headers', 'remove');
+	return $rs if $rs;
 	
 	$rs = $self->_unregisterCronjobPop3fetcher();
 	return $rs if $rs;
@@ -392,7 +394,7 @@ sub _setRoundcubePlugin($$$)
 		error("Unable to read $roundcubeMainIncFile");
 		return 1;
 	}
-	
+
 	if($plugin eq 'contextmenu') {
 		if($action eq 'add') {
 			if($fileContent =~ /imscp_pw_changer/sgm) {
@@ -459,8 +461,8 @@ sub _checkRoundcubePlugins
 	my $self = shift;
 	
 	my $rs = 0;
-	
-	if($self->{'config'}->{'archive_plugin'} eq 'yes') {	
+
+	if($self->{'config'}->{'archive_plugin'} eq 'yes') {
 		$rs = $self->_setRoundcubePlugin('archive', 'add');
 		return $rs if $rs;
 		
@@ -578,7 +580,15 @@ sub _checkRoundcubePlugins
 		$rs = $self->_setRoundcubePlugin('zipdownload', 'remove');
 		return $rs if $rs;
 	}
-	
+
+	if($self->{'config'}->{'additional_message_headers_plugin'} eq 'yes') {
+		$rs = $self->_setRoundcubePlugin('additional_message_headers', 'add');
+		return $rs if $rs;
+	} else {
+		$rs = $self->_setRoundcubePlugin('additional_message_headers', 'remove');
+		return $rs if $rs;
+	}
+
 	$rs = $self->_restartDaemonDovecot();
 	return $rs if $rs;
 	

--- a/incubator/RoundcubePlugins/config-templates/additional_message_headers/config.inc.php
+++ b/incubator/RoundcubePlugins/config-templates/additional_message_headers/config.inc.php
@@ -1,0 +1,4 @@
+<?php
+
+$rcmail_config['additional_message_headers']['X-Originating-IP'] = $_SERVER['REMOTE_ADDR'];
+

--- a/incubator/RoundcubePlugins/config.php
+++ b/incubator/RoundcubePlugins/config.php
@@ -92,5 +92,8 @@ return array(
 	'tasklist_plugin' => 'yes', // YES to enable (default), NO to disable
 
 	// Adds an option to download all attachments of a message in one zip file.
-	'zipdownload_plugin' => 'yes' // YES to enable (default), NO to disable
+	'zipdownload_plugin' => 'yes', // YES to enable (default), NO to disable
+
+	// Adds the originating ip address for the emails sent via roundcube
+	'additional_message_headers_plugin' => 'yes' // YES to enable (default), NO to disable
 );

--- a/incubator/RoundcubePlugins/info.php
+++ b/incubator/RoundcubePlugins/info.php
@@ -34,8 +34,8 @@ return array(
 		'Sascha Bay'
 	),
 	'email' => 'plugins@i-mscp.net',
-	'version' => '0.0.1',
-	'date' => '2013-12-28',
+	'version' => '0.0.2',
+	'date' => '2014-01-30',
 	'name' => 'RoundcubePlugins',
 	'desc' => 'Plugin allows to use Roundcube Plugins with i-MSCP',
 	'url' => 'http://wiki.i-mscp.net/doku.php?id=plugins:roundcubeplugins'


### PR DESCRIPTION
This change adds the originating ip for every ip sent from webmail to allow tracking for abused accounts, see more information on the ticket #895
