### PR TITLE
SpamAssassin: Extend where condition if DCC is not used

### DIFF
--- a/incubator/SpamAssassin/backend/SpamAssassin.pm
+++ b/incubator/SpamAssassin/backend/SpamAssassin.pm
@@ -762,13 +762,19 @@ sub _spamassassinConfig
 	}
 
 	if($saFile eq '00_imscp.cf') {
+		my $disableDCC = "";
+		
+		if($self->{'config'}->{'use_dcc'} eq 'no') {
+			$disableDCC = "AND preference NOT LIKE 'use_dcc'";
+		}
 		$fileContent = process(
 			{
 				DATABASE_HOST => $main::imscpConfig{'DATABASE_HOST'},
 				DATABASE_PORT => $main::imscpConfig{'DATABASE_PORT'},
 				SA_DATABASE_NAME => "$main::imscpConfig{'DATABASE_NAME'}_spamassassin",
 				SA_DATABASE_USER => $self->{'SA_DATABASE_USER'},
-				SA_DATABASE_PASSWORD => $self->{'SA_DATABASE_PASSWORD'}
+				SA_DATABASE_PASSWORD => $self->{'SA_DATABASE_PASSWORD'},
+				DISABLE_DCC => $disableDCC
 			},
 			$fileContent
 		);

--- a/incubator/SpamAssassin/config-templates/spamassassin/00_imscp.cf
+++ b/incubator/SpamAssassin/config-templates/spamassassin/00_imscp.cf
@@ -2,7 +2,7 @@
 user_scores_dsn DBI:mysql:{SA_DATABASE_NAME}:{DATABASE_HOST}:{DATABASE_PORT}
 user_scores_sql_username {SA_DATABASE_USER}
 user_scores_sql_password {SA_DATABASE_PASSWORD}
-user_scores_sql_custom_query SELECT preference, value FROM _TABLE_ WHERE username = _USERNAME_ OR username = '$GLOBAL' OR username = CONCAT('%',_DOMAIN_) ORDER BY username ASC
+user_scores_sql_custom_query SELECT preference, value FROM _TABLE_ WHERE (username = _USERNAME_ OR username = '$GLOBAL' OR username = CONCAT('%',_DOMAIN_)) {DISABLE_DCC} ORDER BY username ASC
 
 # Bayes configuration
 bayes_store_module Mail::SpamAssassin::BayesStore::MySQL


### PR DESCRIPTION
SpamAssassin can't parse any configuration if the module DCC is not loaded. SQL where condition extended to avoid this cosmetic behavior.