### PR TITLE
changed name for port setting in admin backend

### DIFF
--- a/incubator/PolicydWeight/PolicydWeight.php
+++ b/incubator/PolicydWeight/PolicydWeight.php
@@ -40,7 +40,7 @@ class iMSCP_Plugin_PolicydWeight extends iMSCP_Plugin_Action
 
 			iMSCP_Registry::get('dbConfig')->set(
 				'PORT_POLICYD_WEIGHT',
-				$this->getConfigParam('policyd_weight_port', 12525) . ';tcp;POLICYD WEIGHT;1;127.0.0.1'
+				$this->getConfigParam('policyd_weight_port', 12525) . ';tcp;POLICYD_WEIGHT;1;127.0.0.1'
 			);
 		} catch(iMSCP_Exception $e) {
 			throw new iMSCP_Plugin_Exception($e->getMessage(), $e->getCode(), $e);


### PR DESCRIPTION
To avoid the error on changing settings at the Ports Settings Admin Page (admin/settings_ports.php).
No spaces in names allowed.