### PR TITLE
Removed: AllowSupplementaryGroups Option

### DIFF
--- a/incubator/ClamAV/config.php
+++ b/incubator/ClamAV/config.php
@@ -56,7 +56,6 @@ return array(
     'MilterSocketMode'                     => '666',
     'FixStaleSocket'                       => 'true',
     'User'                                 => 'clamav',
-    'AllowSupplementaryGroups'             => 'true',
     'ReadTimeout'                          => '120',
     'Foreground'                           => 'false',
     'PidFile'                              => '/var/run/clamav/clamav-milter.pid',


### PR DESCRIPTION
AllowSupplementaryGroups option no longer supported by clamav version 99.2 it is now enabled by default. If defined clamav will fail to start.